### PR TITLE
Fixed listener loop dying on ChannelClosedException

### DIFF
--- a/Hazel/Udp/UdpConnectionListener.cs
+++ b/Hazel/Udp/UdpConnectionListener.cs
@@ -196,7 +196,7 @@ namespace Impostor.Hazel.Udp
             }
 
             // Write to client.
-            await client.Pipeline.Writer.WriteAsync(data.Buffer);
+            client.Pipeline.Writer.TryWrite(data.Buffer);
         }
 
         /// <summary>

--- a/Hazel/Udp/UdpConnectionListener.cs
+++ b/Hazel/Udp/UdpConnectionListener.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.Extensions.ObjectPool;
 using Serilog;
@@ -138,6 +139,7 @@ namespace Impostor.Hazel.Udp
                             Logger.Fatal("Hazel read 0 bytes from UDP server socket.");
                             continue;
                         }
+                        await ProcessData(data);
                     }
                     catch (SocketException)
                     {
@@ -149,8 +151,11 @@ namespace Impostor.Hazel.Udp
                         // Socket was disposed, don't care.
                         return;
                     }
-
-                    await ProcessData(data);
+                    catch (ChannelClosedException)
+                    {
+                        // Client closed, pretend it didn't happen
+                        continue;
+                    }
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
In UdpConnectionListener, the try/catch block surrounding the receiving while loop is located outside the loop. If ProcessData throws an exception, the entire loop unwinds, logging "Listen loop error" once before ListenAsync terminates. Since there is no restart mechanism and there is only one loop per shared UDP socket, all lobbies on the server become unable to receive packets.
While this usually has no impact, a defect occurs in very rare cases.


The trigger is a race condition within ProcessData:
1. Retrieve the connection from the dictionary (TryGetValue)
2. await client.Pipeline.Writer.WriteAsync(...)

If the connection in question is disposed between steps 1 and 2 (due to a kick, leaving, or a keep-alive timeout calling Pipeline.Writer.Complete()), step 2 results in a write to a closed channel, throwing a ChannelClosedException.